### PR TITLE
Added optional whitespace between checkbox brackets

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -15,7 +15,7 @@ export default class TodoCapture extends Plugin {
 		const keyword = this.settings.keyword || 'TODO';
 
 		// Here, we account for bulleted lines and lines with checkboxes
-		const patternToMatch = new RegExp('^-?\\s*(\\[x?\\])?\\s*' + keyword);
+		const patternToMatch = new RegExp('^-?\\s*(\\[\\s*|x?\\])?\\s*' + keyword);
 		const todoHeading = `## ${keyword}s`;
 
 		if (!editor) {

--- a/main.ts
+++ b/main.ts
@@ -15,7 +15,7 @@ export default class TodoCapture extends Plugin {
 		const keyword = this.settings.keyword || 'TODO';
 
 		// Here, we account for bulleted lines and lines with checkboxes
-		const patternToMatch = new RegExp('^-?\\s*(\\[\\s?|x?\\])?\\s*' + keyword);
+		const patternToMatch = new RegExp('^-?\\s*(\\[\\s?(|)x?\\])?\\s*' + keyword);
 		const todoHeading = `## ${keyword}s`;
 
 		if (!editor) {

--- a/main.ts
+++ b/main.ts
@@ -15,7 +15,7 @@ export default class TodoCapture extends Plugin {
 		const keyword = this.settings.keyword || 'TODO';
 
 		// Here, we account for bulleted lines and lines with checkboxes
-		const patternToMatch = new RegExp('^-?\\s*(\\[\\s*|x?\\])?\\s*' + keyword);
+		const patternToMatch = new RegExp('^-?\\s*(\\[\\s?|x?\\])?\\s*' + keyword);
 		const todoHeading = `## ${keyword}s`;
 
 		if (!editor) {


### PR DESCRIPTION
To adhere to Obsidian (and other Markdown) checkbox syntax a whitespace between the brackets is required to create a checkbox. So `[ ]` instead of `[]`.
See issue #4. 
